### PR TITLE
Balanced enemy and player tap power

### DIFF
--- a/Z-Team Game 2/Assets/Scripts/Enemies/Enemy.cs
+++ b/Z-Team Game 2/Assets/Scripts/Enemies/Enemy.cs
@@ -4,8 +4,8 @@ using UnityEngine;
 
 public abstract class Enemy : MonoBehaviour
 {
-    private const int X_VELOCITY_MIN = 900;
-    private const int X_VELOCITY_MAX = 1050;
+    private const int X_VELOCITY_MIN = 750;
+    private const int X_VELOCITY_MAX = 800;
     private const int Y_VELOCITY_MIN = 7;
     private const int Y_VELOCITY_MAX = 17;
 

--- a/Z-Team Game 2/Assets/Scripts/Pole.cs
+++ b/Z-Team Game 2/Assets/Scripts/Pole.cs
@@ -8,7 +8,7 @@ public class Pole : MonoBehaviour
     public float Rotation { get; private set; }
 
     private const float RESISTANCE = 1.0f;
-    private const float STARTING_FORCE = 100.0f;
+    private const float STARTING_FORCE = 120.0f;
 
     private SpriteRenderer spriteRenderer;
     private float height;


### PR DESCRIPTION
lowered the velocity that enemies can enter with and raised the starting force of the player